### PR TITLE
IMPROVED: right way to name your context .json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Default value: `context`
 
 the src path (relative to template_path) + context_path should be the path of .json context file.
 
+NOTE: the .json file must be the same name as your template name, eg: `index.html` will use the context of `index.json` as its context.
+
 
 ### Usage Examples
 


### PR DESCRIPTION
Context files will only work when name after the Template files. So it is nice to tell the user.
