### PR TITLE
NEW: apply a global context for all  rendered template(optional)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
         options: {
           template_path: 'test/fixtures/templates',
           context_path: 'test/fixtures/context',
+          global_context_file: 'test/fixtures/context/global.json'
         },
         files:[{
           expand: true,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ the src path (relative to template_path) + context_path should be the path of .j
 
 NOTE: the .json file must be the same name as your template name, eg: `index.html` will use the context of `index.json` as its context.
 
+#### options.global_context_file (optional)
+Tpye: `String`
+Default value: `null`
+
+When provide this option like this: `"global_context_file" : "my_global_context.json"`. The context of `my_global_context.json` will apply to all rendered tempates. 
+
 
 ### Usage Examples
 
@@ -81,6 +87,7 @@ grunt.initConfig({
       options: {
         template_path: 'test/fixtures/templates',
         context_path: 'test/fixtures/context',
+        global_context_file : "test/fixures/global.json"
       },
       files:[{
         expand: true,

--- a/bin/jinja2_shell.py
+++ b/bin/jinja2_shell.py
@@ -16,7 +16,7 @@ Options:
 
 
 from docopt import docopt
-import jinja2, json, sys
+import jinja2, json, sys, re
 
 reload(sys)
 sys.setdefaultencoding('utf-8')
@@ -27,7 +27,10 @@ def render(template_file_path=None, data_file_path=None, base_path=None):
   env = jinja2.Environment(loader=jinja2.FileSystemLoader(base_path))
   template = env.get_template(template_file_path)
   if data_file_path:
-    context = json.loads(open(data_file_path).read())
+    file_paht_list = re.split(',\s*',data_file_path)
+    context = {}
+    for filePath in file_paht_list:
+          context = dict((json.loads(open(filePath).read())).items()+context.items())
   else:
     context = {}
   print template.render(context)

--- a/tasks/jinja2.js
+++ b/tasks/jinja2.js
@@ -91,10 +91,19 @@ module.exports = function(grunt) {
       var context_path = options.context_path + template_path.replace(/\.\w+$/,'.json')
       //test context file
       var use_context = grunt.file.exists(context_path) && grunt.file.readJSON(context_path)
+      //global context file
+      var global_context_file = options.global_context_file
 
       var args = ['-t', template_path, '-b', options.template_path]
-      if (use_context){
+      if (use_context && global_context_file){
+        var combinedPath = context_path + "," + global_context_file
+        // args.push('-d', combinedPath)
+        args.push('-d', combinedPath)
+        console.log("combinedPath", combinedPath);
+      } else if(use_context) {
         args.push('-d', context_path)
+      } else if(global_context_file) {
+        args.push('-d', global_context_file)
       }
       // grunt.log.writeln(template_path, context_path, args);
       //run python command

--- a/test/expected/albums.html
+++ b/test/expected/albums.html
@@ -10,3 +10,7 @@ link
 lastName
 
 userID
+
+
+userID
+value of global var1

--- a/test/expected/no_context.html
+++ b/test/expected/no_context.html
@@ -1,1 +1,2 @@
 This is a test file.
+value of global var1

--- a/test/fixtures/context/global.json
+++ b/test/fixtures/context/global.json
@@ -1,0 +1,8 @@
+{
+    "photographer": {
+        "user_id": "userID_from_global.json"
+    },
+    "globalVar": {
+        "var1": "value of global var1"
+    }
+}

--- a/test/fixtures/templates/albums.tpl
+++ b/test/fixtures/templates/albums.tpl
@@ -11,3 +11,8 @@ link
 {% block content %}
 {{photographer.user_id}}
 {% endblock %}
+
+{% block globalContext %}
+{{photographer.user_id}}
+{{globalVar.var1}}
+{% endblock %}

--- a/test/fixtures/templates/module/base.tpl
+++ b/test/fixtures/templates/module/base.tpl
@@ -5,3 +5,4 @@ html
 456
 {% include 'module/header.tpl' %}
 {% block content %}{% endblock %}
+{% block globalContext %}{% endblock %}

--- a/test/fixtures/templates/no_context.tpl
+++ b/test/fixtures/templates/no_context.tpl
@@ -1,1 +1,2 @@
 This is a test {% if 2 > 1 %}file.{% endif %}
+{{globalVar.var1}}


### PR DESCRIPTION
By supplying the option `global_context_file`, a global context will apply to all rendered templates.
